### PR TITLE
Updated selector types, to use Attributes first

### DIFF
--- a/src/utils/FdEvents.ts
+++ b/src/utils/FdEvents.ts
@@ -124,11 +124,11 @@ export interface Template {
 }
 
 export const UNIQUE_SELECTOR_OPTIONS = {
-    selectorTypes: ['ID', 'Tag', 'NthChild'],
+    selectorTypes: ['Attributes', 'ID', 'Tag', 'NthChild'],
 };
 
 export const UNIQUE_SELECTOR_OPTIONS_WITHOUT_ID = {
-    selectorTypes: ['Tag', 'NthChild'],
+    selectorTypes: ['Attributes', 'Tag', 'NthChild'],
 };
 
 export interface Options {


### PR DESCRIPTION
As stated in the documentation,

>  Best Practice: Use `data-*` attributes to provide context to your selectors and isolate them from CSS or JS changes.

So, the recommendation is to always give precedence in using data attributes.

### First impressions

As soon as I started using fd-cypress-recorder, I got a bunch of `#app > :nth-child(1)`, because my application is already using the recommended data attributes. So, this change it will be a great deal for those, like myself, that are using data attributes from day one with cypress.

### References

- <https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements>