### PR TITLE
fix(frames): allow to record inside frames

### DIFF
--- a/manifest/chrome/manifest.json
+++ b/manifest/chrome/manifest.json
@@ -41,6 +41,7 @@
     },
     "content_scripts": [
         {
+            "all_frames": true,
             "matches": ["*://*/*"],
             "css": ["content.css"],
             "js": ["content.js"],

--- a/manifest/firefox/manifest.json
+++ b/manifest/firefox/manifest.json
@@ -43,6 +43,7 @@
     },
     "content_scripts": [
         {
+            "all_frames": true,
             "matches": ["*://*/*"],
             "css": ["content.css"],
             "js": ["content.js"],


### PR DESCRIPTION
This is particularly useful for recording tests on storybook or
webextensions that inject iframes